### PR TITLE
chore: import repository https://github.com/wluh1/jx-go-quickstart.git

### DIFF
--- a/.jx/gitops/source-config.yaml
+++ b/.jx/gitops/source-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: gitops.jenkins-x.io/v1alpha1
+kind: SourceConfig
+metadata:
+  creationTimestamp: null
+spec:
+  groups:
+  - owner: wluh1
+    provider: https://github.com
+    providerKind: github
+    repositories:
+    - name: jx-go-quickstart
+    scheduler: in-repo
+  slack:
+    channel: '#jenkins-x-pipelines'
+    kind: failureOrNextSuccess
+    pipeline: release

--- a/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/config-cm.yaml
@@ -7,6 +7,7 @@ data:
       LinkURL: null
     in_repo_config:
       enabled:
+        wluh1/jx-go-quickstart: true
         wluh1/k8s-ci-cd-jx: true
     plank: {}
     pod_namespace: jx
@@ -19,6 +20,7 @@ data:
         required-if-present-contexts: null
         skip-unknown-contexts: false
       merge_method:
+        wluh1/jx-go-quickstart: merge
         wluh1/k8s-ci-cd-jx: merge
       queries:
       - labels:
@@ -31,6 +33,7 @@ data:
         - needs-rebase
         repos:
         - wluh1/k8s-ci-cd-jx
+        - wluh1/jx-go-quickstart
       - labels:
         - updatebot
         missingLabels:
@@ -41,6 +44,7 @@ data:
         - needs-rebase
         repos:
         - wluh1/k8s-ci-cd-jx
+        - wluh1/jx-go-quickstart
       target_url: http://lighthouse-jx.35.241.195.23/merge/status
 kind: ConfigMap
 metadata:

--- a/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
+++ b/config-root/namespaces/jx/lighthouse-config/plugins-cm.yaml
@@ -6,6 +6,10 @@ data:
       repos:
       - wluh1/k8s-ci-cd-jx
       require_self_approval: true
+    - lgtm_acts_as_approve: true
+      repos:
+      - wluh1/jx-go-quickstart
+      require_self_approval: true
     cat: {}
     cherry_pick_unapproved: {}
     config_updater:
@@ -16,6 +20,11 @@ data:
         env/prow/plugins.yaml:
           name: plugins
     external_plugins:
+      wluh1/jx-go-quickstart:
+      - endpoint: http://cd-indicators.jx.svc.cluster.local/lighthouse/events
+        name: cd-indicators
+      - endpoint: http://lighthouse-webui-plugin.jx.svc.cluster.local/lighthouse/events
+        name: lighthouse-webui-plugin
       wluh1/k8s-ci-cd-jx:
       - endpoint: http://cd-indicators.jx.svc.cluster.local/lighthouse/events
         name: cd-indicators
@@ -26,6 +35,22 @@ data:
       additional_labels: null
     owners: {}
     plugins:
+      wluh1/jx-go-quickstart:
+      - approve
+      - assign
+      - blunderbuss
+      - help
+      - hold
+      - lgtm
+      - lifecycle
+      - override
+      - size
+      - trigger
+      - wip
+      - heart
+      - cat
+      - dog
+      - pony
       wluh1/k8s-ci-cd-jx:
       - config-updater
       - approve
@@ -55,6 +80,11 @@ data:
     - repos:
       - wluh1/k8s-ci-cd-jx
       trusted_org: todo
+    - repos:
+      - wluh1/jx-go-quickstart
+      trusted_org: todo
+    welcome:
+    - message_template: Welcome
 kind: ConfigMap
 metadata:
   creationTimestamp: null

--- a/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-foghorn-deploy.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         app: lighthouse-foghorn
       annotations:
-        jenkins-x.io/hash: '8c3bf3ca7988bf826cef572235492909cb215964585945cc28955e9e259f1292'
+        jenkins-x.io/hash: '15f1abc2048cc0c215f88a83f7472be1a6b31b1d0db13d1c5cb11dc4cb91a3f9'
     spec:
       serviceAccountName: lighthouse-foghorn
       containers:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-keeper-deploy.yaml
@@ -27,7 +27,7 @@ spec:
         ad.datadoghq.com/keeper.logs: '[{"source":"lighthouse","service":"keeper"}]'
         prometheus.io/port: "9090"
         prometheus.io/scrape: "true"
-        jenkins-x.io/hash: '8c3bf3ca7988bf826cef572235492909cb215964585945cc28955e9e259f1292'
+        jenkins-x.io/hash: '15f1abc2048cc0c215f88a83f7472be1a6b31b1d0db13d1c5cb11dc4cb91a3f9'
       labels:
         app: lighthouse-keeper
     spec:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-tekton-controller-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     metadata:
       labels:
         app: lighthouse-tekton-controller
-      annotations: {jenkins-x.io/hash: '8c3bf3ca7988bf826cef572235492909cb215964585945cc28955e9e259f1292'}
+      annotations: {jenkins-x.io/hash: '15f1abc2048cc0c215f88a83f7472be1a6b31b1d0db13d1c5cb11dc4cb91a3f9'}
     spec:
       serviceAccountName: lighthouse-tekton-controller
       containers:

--- a/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
+++ b/config-root/namespaces/jx/lighthouse/lighthouse-webhooks-deploy.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         prometheus.io/port: "2112"
         prometheus.io/scrape: "true"
-        jenkins-x.io/hash: '8c3bf3ca7988bf826cef572235492909cb215964585945cc28955e9e259f1292'
+        jenkins-x.io/hash: '15f1abc2048cc0c215f88a83f7472be1a6b31b1d0db13d1c5cb11dc4cb91a3f9'
     spec:
       serviceAccountName: lighthouse-webhooks
       containers:

--- a/config-root/namespaces/jx/source-repositories/wluh1-jx-go-quickstart.yaml
+++ b/config-root/namespaces/jx/source-repositories/wluh1-jx-go-quickstart.yaml
@@ -1,0 +1,22 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: wluh1
+    provider: github
+    repository: jx-go-quickstart
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  name: wluh1-jx-go-quickstart
+  namespace: jx
+spec:
+  httpCloneURL: https://github.com/wluh1/jx-go-quickstart.git
+  org: wluh1
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: jx-go-quickstart
+  scheduler:
+    kind: ""
+    name: in-repo
+  url: https://github.com/wluh1/jx-go-quickstart


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the CI/CD configuration](https://jenkins-x.io/v3/about/how-it-works/#importing--creating-quickstarts) which will create a second commit on this Pull Request before it auto merges
